### PR TITLE
fix: enable auto-merge for release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,6 @@ jobs:
 
       - name: Auto-merge release PR
         if: ${{ steps.release.outputs.pr != '' }}
-        run: gh pr merge --rebase "${{ fromJSON(steps.release.outputs.pr).number }}"
+        run: gh pr merge --rebase --auto --repo "${{ github.repository }}" "${{ fromJSON(steps.release.outputs.pr).number }}"
         env:
           GH_TOKEN: ${{ secrets.POKEMON_RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Pass the repository explicitly to `gh pr merge` so release-please can auto-merge the generated PR.