### PR TITLE
fix: let solo mode load promptly when sync is unavailable

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge minor/patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1536,26 +1536,35 @@ onMounted(async () => {
   const startupMode = await restoreMostRecentRun(initialRunMode)
 
   // Init sync session and sync before showing content so session metadata
-  // and merged state are final on first render (avoids team reorder flash)
+  // and merged state are final on first render (avoids team reorder flash).
+  // Race against a timeout so offline users aren't blocked waiting for
+  // Supabase calls that will never resolve.
   if (startupMode === RUN_MODES.SOLO && isSoloSyncAvailable) {
-    try {
-      await initSoloSyncSession(
-        () => buildSoloSnapshot(),
-        (snapshot) => applySoloRemoteSnapshot(snapshot),
-        buildSoloSessionCallbacks(),
-      )
-    } catch (err) {
-      console.error('Failed to init solo sync session:', err)
-    }
-    if (hasSoloRemoteSession.value) {
+    const syncPromise = (async () => {
       try {
-        await syncSoloSession()
-        await saveSoloRunToIndex(buildSoloSnapshot())
-        subscribeSolo()
+        await initSoloSyncSession(
+          () => buildSoloSnapshot(),
+          (snapshot) => applySoloRemoteSnapshot(snapshot),
+          buildSoloSessionCallbacks(),
+        )
       } catch (err) {
-        console.error('Solo auto-sync on mount failed:', err)
+        console.error('Failed to init solo sync session:', err)
       }
-    }
+      if (hasSoloRemoteSession.value) {
+        try {
+          await syncSoloSession()
+          await saveSoloRunToIndex(buildSoloSnapshot())
+          subscribeSolo()
+        } catch (err) {
+          console.error('Solo auto-sync on mount failed:', err)
+        }
+      }
+    })()
+
+    await Promise.race([
+      syncPromise,
+      new Promise((resolve) => setTimeout(resolve, 3000)),
+    ])
   }
 
   ready.value = true


### PR DESCRIPTION
### Bug Fixes
- Let solo players reach the app without getting stuck behind sync startup work when Supabase is slow or unavailable, while still allowing sync to continue when it becomes available.

### Continuous Integration
- Enable automatic merging for Dependabot updates through CI so routine dependency maintenance can land with less manual overhead.