### PR TITLE
ci: harden release automation

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,6 @@
 name: Dependabot Auto-Merge
 
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,14 +19,8 @@ jobs:
           token: ${{ secrets.POKEMON_RELEASE_PLEASE_TOKEN }}
 
       - name: Auto-merge release PR
-        run: |
-          PR_NUMBER=$(gh pr list \
-            --repo "${{ github.repository }}" \
-            --label "autorelease: pending" \
-            --json number \
-            --jq '.[0].number')
-          if [ -n "$PR_NUMBER" ]; then
-            gh pr merge --rebase --auto --repo "${{ github.repository }}" "$PR_NUMBER"
-          fi
+        if: steps.release.outputs.prs_created == 'true'
+        run: gh pr merge --rebase --auto --repo "${{ github.repository }}" "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.POKEMON_RELEASE_PLEASE_TOKEN }}
+          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}


### PR DESCRIPTION
Use pull_request_target for Dependabot auto-merge and merge the release-please PR directly from the created PR number.