### PR TITLE
fix: parse release PR number before auto-merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,10 @@ jobs:
 
       - name: Auto-merge release PR
         if: steps.release.outputs.prs_created == 'true'
-        run: gh pr merge --rebase --auto --repo "${{ github.repository }}" "$PR_NUMBER"
+        run: |
+          PR_NUMBER="$(jq -r '.number // empty' <<<"$PR_JSON")"
+          test -n "$PR_NUMBER"
+          gh pr merge --rebase --auto --repo "${{ github.repository }}" "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.POKEMON_RELEASE_PLEASE_TOKEN }}
-          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
+          PR_JSON: ${{ steps.release.outputs.pr }}


### PR DESCRIPTION
Read the release PR JSON output at runtime and validate the extracted number before calling `gh pr merge`.